### PR TITLE
Add account, user, scope, client, and account_scope migrations

### DIFF
--- a/migrations/20150923192914_account.js
+++ b/migrations/20150923192914_account.js
@@ -1,0 +1,11 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.createTable('Account', function(table) {
+    table.increments('id').primary();
+    table.string('username').notNullable().unique();
+    table.string('password');
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.dropTable('Account');
+};

--- a/migrations/20150923193049_user.js
+++ b/migrations/20150923193049_user.js
@@ -1,0 +1,10 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.createTable('APIUser', function(table) {
+    table.integer('person_id').notNullable().unique().references('id').inTable('Person');
+    table.integer('account_id').notNullable().unique().references('id').inTable('Account');
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.dropTable('APIUser');
+};

--- a/migrations/20150923193555_scope.js
+++ b/migrations/20150923193555_scope.js
@@ -1,0 +1,11 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.createTable('Scope', function(table) {
+    table.increments('id').primary();
+    table.string('key').notNullable().unique();
+    table.string('description').notNullable();
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.dropTable('Scope');
+};

--- a/migrations/20150923193830_client.js
+++ b/migrations/20150923193830_client.js
@@ -1,0 +1,11 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.createTable('Client', function(table) {
+    table.increments('id').primary();
+    table.string('name').unique().notNullable();
+    table.string('callback_url').notNullable();
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.dropTable('Client');
+};

--- a/migrations/20150923194256_account_scope.js
+++ b/migrations/20150923194256_account_scope.js
@@ -1,0 +1,10 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.createTable('Account_Scope', function(table) {
+    table.integer('account_id').notNullable().references('id').inTable('Account');
+    table.integer('scope_id').notNullable().references('id').inTable('Scope');
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.schema.dropTable('Account_Scope');
+};

--- a/tests/person.coffee
+++ b/tests/person.coffee
@@ -15,7 +15,7 @@ describe 'Person', ->
       done()
 
   beforeEach (done) ->
-    bookshelf.knex('Person').truncate()
+    bookshelf.knex('Person').delete()
     .then ->
       done()
     .catch ->
@@ -166,7 +166,7 @@ describe 'Person', ->
     it 'does not update a non-existent person', (done) ->
       req =
         method: 'PUT'
-        url: '/api/v1/person/42'
+        url: '/api/v1/person/1'
         payload:
           first_name: 'First'
           last_name: 'Last'
@@ -174,7 +174,7 @@ describe 'Person', ->
         res.statusCode.should.equal 404
         req2 =
           method: 'GET'
-          url: '/api/v1/person/42'
+          url: '/api/v1/person/1'
         server.inject req2, (res2) ->
           res2.statusCode.should.equal 404
           done()


### PR DESCRIPTION
To simplify initial development, we're going to assume that all client apps are internally-built. Thus, we do not need to consider client authorization/authorization bypass; all clients will be authorized automatically and will not need subset authorizations
