### PR TITLE
Add device ID to alerts response

### DIFF
--- a/lib/api/v1/active911/Alert.coffee
+++ b/lib/api/v1/active911/Alert.coffee
@@ -61,6 +61,7 @@ module.exports = (server) ->
       getCachedDeviceName(rawResponse.device.id).then (name) ->
         response =
             name: name
+            deviceId: rawResponse.device.id
             response: rawResponse.response
             timestamp: rawResponse.timestamp
         fulfill response


### PR DESCRIPTION
We need the device ID as a unique identifier for the person sending the
response in the client.
